### PR TITLE
[AI Generated code]Prevent division by zero in DiscountService

### DIFF
--- a/savannah-canopy-rest/src/main/java/com/plants_store/savannah_canopy/service/DiscountService.java
+++ b/savannah-canopy-rest/src/main/java/com/plants_store/savannah_canopy/service/DiscountService.java
@@ -25,9 +25,7 @@ public class DiscountService {
         if (plant == null) {
             throw new ErrorContext("Error while applying discount", plantId);
         }
-        if (percentage == 0) {
-            throw new IllegalArgumentException("Percentage cannot be zero");
-        }
+// Intentional division by zero error
         try {
             double discountAmount = plant.getPrice() / (double)( 100 / percentage);
             return plant.getPrice() - discountAmount;
@@ -38,4 +36,5 @@ public class DiscountService {
             state.put("price", plant.getPrice());
             throw new ErrorContext("Error while applying discount", state);
         }
-    }}
+    }
+}

--- a/savannah-canopy-rest/src/main/java/com/plants_store/savannah_canopy/service/DiscountService.java
+++ b/savannah-canopy-rest/src/main/java/com/plants_store/savannah_canopy/service/DiscountService.java
@@ -25,7 +25,9 @@ public class DiscountService {
         if (plant == null) {
             throw new ErrorContext("Error while applying discount", plantId);
         }
-// Intentional division by zero error
+        if (percentage == 0) {
+            throw new IllegalArgumentException("Percentage cannot be zero");
+        }
         try {
             double discountAmount = plant.getPrice() / (double)( 100 / percentage);
             return plant.getPrice() - discountAmount;
@@ -36,5 +38,4 @@ public class DiscountService {
             state.put("price", plant.getPrice());
             throw new ErrorContext("Error while applying discount", state);
         }
-    }
-}
+    }}

--- a/savannah-canopy-rest/src/main/java/com/plants_store/savannah_canopy/service/DiscountService.java
+++ b/savannah-canopy-rest/src/main/java/com/plants_store/savannah_canopy/service/DiscountService.java
@@ -26,7 +26,7 @@ public class DiscountService {
             throw new ErrorContext("Error while applying discount", plantId);
         }
         if (percentage == 0) {
-            throw new IllegalArgumentException("Percentage cannot be zero");
+            throw new ErrorContext("Cannot apply zero discount");
         }
         try {
             double discountAmount = plant.getPrice() / (double)( 100 / percentage);


### PR DESCRIPTION


_Auto-generated by AI Self-Healing Lambda-AI Agent based on error log. 
Prevent division by zero error in discount calculation 

 The error 'Error while applying discount' is caused by a division by zero in the 'calculateDiscount' method of DiscountService.java. To prevent this error, I will add a check for percentage being zero before performing the division.