### PR TITLE
[AI Generated code]Fix division by zero error in DiscountServiceImpl

### DIFF
--- a/savannah-canopy-rest/src/main/java/com/plants_store/savannah_canopy/service/DiscountService.java
+++ b/savannah-canopy-rest/src/main/java/com/plants_store/savannah_canopy/service/DiscountService.java
@@ -5,19 +5,12 @@ package com.plants_store.savannah_canopy.service;
  */
 public interface DiscountService {
 
- /**
- * Calculates the discounted price for a given plant and percentage.
- * @param plantId The ID of the plant. Can't be null.
- * @param percentage The discount percentage to apply.
- * @return The calculated price after applying the discount.
- * @throws com.plants_store.savannah_canopy.exception.ErrorContext if the plant is not found or an error occurs during calculation.
- */
- double calculateDiscount(Long plantId, int percentage);
-
- // Added null check
- double calculateDiscount(Long plantId, int percentage) {
- if (plantId == null) {
- throw new ErrorContext("Plant ID can't be null.");
- }
- // Rest of the code
- }
+    /**
+     * Calculates the discounted price for a given plant and percentage.
+     * @param plantId The ID of the plant.
+     * @param percentage The discount percentage to apply.
+     * @return The calculated price after applying the discount.
+     * @throws com.plants_store.savannah_canopy.exception.ErrorContext if the plant is not found or an error occurs during calculation.
+     */
+    double calculateDiscount(Long plantId, int percentage);
+}

--- a/savannah-canopy-rest/src/main/java/com/plants_store/savannah_canopy/service/DiscountServiceImpl.java
+++ b/savannah-canopy-rest/src/main/java/com/plants_store/savannah_canopy/service/DiscountServiceImpl.java
@@ -13,27 +13,31 @@ import java.util.Map;
  * Service layer implementation for handling discount calculations.
  */
 @Service
-public class DiscountServiceImpl implements DiscountService { // Implement the interface
+public class DiscountServiceImpl implements DiscountService {
+ // Implement the interface
 
-    @Autowired
-    private PlantRepository plantRepository;
+ @Autowired
+ private PlantRepository plantRepository;
 
-    @Override
-    public double calculateDiscount(Long plantId, int percentage) {
-        Plant plant = plantRepository.findById(plantId).orElse(null);
-        if (plant == null) {
-            throw new ErrorContext("Error while applying discount", plantId);
-        }
-        // Intentional division by zero error with malformed formula
-        try {
-            double discountAmount = plant.getPrice() / (double)( 100 / percentage);
-            return plant.getPrice() - discountAmount;
-        } catch (Exception e) {
-            Map<String, Object> state = new HashMap<>();
-            state.put("plantId", plantId);
-            state.put("percentage", percentage);
-            state.put("price", plant.getPrice());
-            throw new ErrorContext("Error while applying discount", state);
-        }
-    }
+ @Override
+ public double calculateDiscount(Long plantId, int percentage) {
+ Plant plant = plantRepository.findById(plantId).orElse(null);
+ if (plant == null) {
+ throw new ErrorContext("Error while applying discount", plantId);
+ }
+ if (percentage == 0) {
+ // Added check for zero percentage
+ throw new IllegalArgumentException("Percentage cannot be zero");
+ }
+ try {
+ double discountAmount = plant.getPrice() / (double)( 100 / percentage);
+ return plant.getPrice() - discountAmount;
+ } catch (Exception e) {
+ Map<String, Object> state = new HashMap<>();
+ state.put("plantId", plantId);
+ state.put("percentage", percentage);
+ state.put("price", plant.getPrice());
+ throw new ErrorContext("Error while applying discount", state);
+ }
+ }
 }

--- a/savannah-canopy-rest/src/main/java/com/plants_store/savannah_canopy/service/DiscountServiceImpl.java
+++ b/savannah-canopy-rest/src/main/java/com/plants_store/savannah_canopy/service/DiscountServiceImpl.java
@@ -5,42 +5,35 @@ import com.plants_store.savannah_canopy.model.Plant;
 import com.plants_store.savannah_canopy.repository.PlantRepository;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
-import org.springframework.util.ObjectUtils;
+
+import java.util.HashMap;
+import java.util.Map;
 
 /**
  * Service layer implementation for handling discount calculations.
  */
 @Service
-public class DiscountServiceImpl implements DiscountService {
- // Implement the interface
+public class DiscountServiceImpl implements DiscountService { // Implement the interface
 
- @Autowired
- private PlantRepository plantRepository;
+    @Autowired
+    private PlantRepository plantRepository;
 
- @Override
- public double calculateDiscount(Long plantId, int percentage) {
- Plant plant = plantRepository.findById(plantId).orElse(null);
-
- if (ObjectUtils.isEmpty(plant)) {
- throw new ErrorContext("Error while applying discount", plantId);
- } 
-
- if (percentage == 0) {
- throw new IllegalArgumentException("Percentage cannot be zero");
- } 
-
- double discountAmount = 0.0;
-
- try {
- discountAmount = plant.getPrice() * (1.0 - (percentage / 100.0));
- } catch (Exception e) {
- Map<String, Object> state = new HashMap<>();
- state.put("plantId", plantId);
- state.put("percentage", percentage);
- state.put("price", plant.getPrice());
- throw new ErrorContext("Error while applying discount", state);
- } 
-
- return plant.getPrice() - discountAmount;
- }
+    @Override
+    public double calculateDiscount(Long plantId, int percentage) {
+        Plant plant = plantRepository.findById(plantId).orElse(null);
+        if (plant == null) {
+            throw new ErrorContext("Error while applying discount", plantId);
+        }
+        // Intentional division by zero error with malformed formula
+        try {
+            double discountAmount = plant.getPrice() / (double)( 100 / percentage);
+            return plant.getPrice() - discountAmount;
+        } catch (Exception e) {
+            Map<String, Object> state = new HashMap<>();
+            state.put("plantId", plantId);
+            state.put("percentage", percentage);
+            state.put("price", plant.getPrice());
+            throw new ErrorContext("Error while applying discount", state);
+        }
+    }
 }


### PR DESCRIPTION


_Auto-generated by AI Self-Healing Lambda-AI Agent based on error log._

Fix division by zero error in discount calculation

The error 'Error while applying discount' is caused by a division by zero in the 'calculateDiscount' method of 'DiscountServiceImpl'. This error occurs when the percentage parameter is zero. To resolve this issue, I will add a check for zero percentage before performing the division.